### PR TITLE
Update Performing-Networking-Tasks.md

### DIFF
--- a/reference/docs-conceptual/samples/Performing-Networking-Tasks.md
+++ b/reference/docs-conceptual/samples/Performing-Networking-Tasks.md
@@ -113,7 +113,7 @@ Address   ResponseTime StatusCode
 
 ```powershell
 1..254| ForEach-Object -Process {
-  Get-CimInstance -Class Win32_PingStatus -Filter ("Address='192.168.1.$_ '") } |
+  Get-CimInstance -Class Win32_PingStatus -Filter ("Address='192.168.1.$_'") } |
     Select-Object -Property Address,ResponseTime,StatusCode
 ```
 


### PR DESCRIPTION
1..254| ForEach-Object -Process {
  Get-CimInstance -Class Win32_PingStatus -Filter ("Address='192.168.1.$_'") } |
    Select-Object -Property Address,ResponseTime,StatusCode  
$_后多了一个空格，导致命令运行失败

建议的有用信息：
1.请参阅 [快速入门本地化样式指南](https://docs.microsoft.com/globalization/localization/styleguides)，了解 Microsoft 风格指南中**最重要的十大规则**。
2.请参阅 [Microsoft 语言门户](https://www.microsoft.com/language)，查看各 Microsoft 产品的**标准化术语翻译**。
